### PR TITLE
DOPS-1741: Deploy Iroha2 Block Explorer testing env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN npm install
 COPY ./ .
 RUN npm run build
 
-FROM nginx as production-stage
+FROM nginxinc/nginx-unprivileged:alpine
 RUN mkdir /app
 COPY --from=build-stage /app/dist /app
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN npm install
 COPY ./ .
 RUN npm run build
 
-FROM nginxinc/nginx-unprivileged:alpine
+FROM nginxinc/nginx-unprivileged:mainline
 RUN mkdir /app
 COPY --from=build-stage /app/dist /app
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,7 +15,7 @@ http {
   sendfile        on;
   keepalive_timeout  65;
   server {
-    listen       80;
+    listen       8080;
     server_name  localhost;
     location / {
       root   /app;


### PR DESCRIPTION
# Task
[DOPS-1741]: Deploy Iroha2 Block Explorer testing env

## Changes
Switch to unprevilidge nginx container and update Dockerfile

## Author
Sign-by-off: Vasilii Zyabkin <zyabkin@soramitsu.co.jp>

[DOPS-1741]: https://soramitsu.atlassian.net/browse/DOPS-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ