### PR TITLE
DOPS-1741: Deploy Iroha2 Block Explorer testing env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM node:latest as build-stage
-WORKDIR /app
-COPY package*.json ./
-RUN npm install
-COPY ./ .
-RUN npm run build
-
-FROM nginxinc/nginx-unprivileged:mainline
-USER nginx
-COPY --from=build-stage /app/dist /usr/share/nginx/html
+FROM      node:18.2.0-bullseye
+COPY      . /app
+WORKDIR   /app
+RUN       npm install && npm run build
+USER      node
+ENV       PORT=8080
+CMD       ["node", "app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-FROM      node:18.2.0-bullseye
-COPY      . /app
-WORKDIR   /app
-RUN       npm install && npm run build
-USER      node
-ENV       PORT=8080
-CMD       ["node", "app"]
+FROM nginxinc/nginx-unprivileged:mainline
+USER nginx
+COPY ./build /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN npm run build
 
 FROM nginxinc/nginx-unprivileged:mainline
 ENV LOAD_DIR=/app
-RUN adduser --disabled-password --gecos "" iroha && \
-    mkdir -p ${LOAD_DIR} && \
-    chown -R iroha ${LOAD_DIR}
+USER root
+RUN mkdir -p ${LOAD_DIR}
+RUN chown -R nginx:nginx ${LOAD_DIR}
+USER nginx
+WORKDIR ${LOAD_DIR}
 COPY --from=build-stage /app/dist ${LOAD_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,5 @@ COPY ./ .
 RUN npm run build
 
 FROM nginxinc/nginx-unprivileged:mainline
-ENV LOAD_DIR=/app
-USER root
-RUN mkdir -p ${LOAD_DIR} && \
-    chown -R nginx:nginx ${LOAD_DIR}
 USER nginx
-WORKDIR ${LOAD_DIR}
-COPY --from=build-stage /app/dist ${LOAD_DIR}
+COPY --from=build-stage /app/dist /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY ./ .
 RUN npm run build
 
 FROM nginxinc/nginx-unprivileged:mainline
-RUN mkdir /app
-COPY --from=build-stage /app/dist /app
-COPY nginx.conf /etc/nginx/nginx.conf
+ENV LOAD_DIR=/app
+RUN adduser --disabled-password --gecos "" iroha && \
+    mkdir -p ${LOAD_DIR} && \
+    chown -R iroha ${LOAD_DIR}
+COPY --from=build-stage /app/dist ${LOAD_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:mainline
 ENV LOAD_DIR=/app
 USER root
-RUN mkdir -p ${LOAD_DIR}
-RUN chown -R nginx:nginx ${LOAD_DIR}
+RUN mkdir -p ${LOAD_DIR} && \
+    chown -R nginx:nginx ${LOAD_DIR}
 USER nginx
 WORKDIR ${LOAD_DIR}
 COPY --from=build-stage /app/dist ${LOAD_DIR}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 def pipeline = new org.js.AppPipeline(
     packageManager:     'npm',
-    buildCmds: ["npm run build"],
+    buildCmds: ["npm install && npm run build"],
     steps:              this,
     test:               false,
     dockerImageName:    'iroha2/iroha2-block-explorer-web',


### PR DESCRIPTION
# Task
[DOPS-1741]: Deploy Iroha2 Block Explorer testing env

## Changes
Switch to unprevilidge nginx container and update Dockerfile according to it

## Author
Sign-by-off: Vasilii Zyabkin <zyabkin@soramitsu.co.jp>

[DOPS-1741]: https://soramitsu.atlassian.net/browse/DOPS-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ