### PR TITLE
Add a store key count in an asset

### DIFF
--- a/src/shared/api/mock-factories/asset.ts
+++ b/src/shared/api/mock-factories/asset.ts
@@ -17,7 +17,7 @@ export function makeAssetValue(): AssetValue {
   let c;
 
   switch (t) {
-    case 'Store': c = {}; break;
+    case 'Store': c = '🔑: 0'; break;
     case 'Fixed': c = String(randNumber({ fraction: 6 })); break;
     default: c = String(randNumber()); break;
   }


### PR DESCRIPTION
Adds a template of the `Store` asset key count as discussed on the meeting. Modifies only the mocks.