### PR TITLE
[feature] Add a "copy" button into the latest transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,33 @@ Build artifacts will be located at `dist` dir.
 
 `Dockerfile` with `nginx.conf` are also provided. Based on [Deployment > Docker (nginx)](https://cli.vuejs.org/guide/deployment.html#docker-nginx).
 
+## Development
+
+### Connecting to a BCE backend
+
+One may want to see to see how the backend responds in the real time,
+but pointing the API endpoint directly in the `VITE_API_URL` property of an `.env` file
+would lead to a lot of errors like this one:
+
+    Access to fetch at 'http://localhost:port_A/...' from origin 'http://localhost:port_B' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
+
+Vite can be configured to proxy the responses.
+
+So, we first return to the `.env` file and configure `VITE_API_URL` property as `http://localhost:5173/api-proxy`, if our `dev` shows the port as 5173.
+
+Then we go to the Vite configuration in `vite.config.js` and add a new part in our `defineConfig` section,
+where our `target` points to the host and the port of our BCE backend instance.
+
+```js
+  server: {
+    proxy: {
+      '/api-proxy': {
+        target: 'http://127.0.0.1:4000',
+        changeOrigin: true,
+        secure: false,
+        ws: false,
+        rewrite: (path) => '/api/v1' + path.replace(/api-proxy\//, ''),
+      },
+    },
+  },
+```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ Build artifacts will be located at `dist` dir.
 
 ## Development
 
+### Setting up the `.env` file
+
+You need a file with environment variables to configure Vite for the frontend to properly request either mock data or interact with the backend.
+
+To enable the mocks, write:
+
+```
+VITE_FAKE_API_ENABLED=TRUE
+```
+
+To interact with the backend, assuming you'll add an API proxy as described below, write:
+
+```
+VITE_API_URL=http://localhost:5173/api-proxy
+VITE_FAKE_API_ENABLED=FALSE
+```
+
 ### Connecting to a BCE backend
 
 One may want to see to see how the backend responds in the real time,

--- a/src/widgets/latest-transactions/LatestTransactions.vue
+++ b/src/widgets/latest-transactions/LatestTransactions.vue
@@ -18,6 +18,7 @@
           :hash="transaction.hash"
           type="medium"
           :link="'/transactions/' + transaction.hash"
+          copy
         />
 
         <div class="latest-transactions__info">


### PR DESCRIPTION
Made to be comparable to the "full hash" PR (https://github.com/soramitsu/iroha2-block-explorer-web/pull/24), because we've previously discussed removing the shortening.
Seems reasonable to add to me, plus, the change is small.

![Screenshot_2022-11-22_08-04-50](https://user-images.githubusercontent.com/2552837/203239429-eced3514-5175-4a4f-a1db-20794278ea48.png)
