### PR TITLE
docs: add compat & versioning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ Build artifacts will be located at `dist` dir.
 
 ### Docker
 
-`Dockerfile` with `nginx.conf` are also provided. Based on [Deployment > Docker (nginx)](https://cli.vuejs.org/guide/deployment.html#docker-nginx).
+`Dockerfile` is also provided.
 
 ## Development
 
 Frontend sends API requests to its own base URL (`<base>/api/v1`) by default. When served via Vite, it is automatically
 proxied to `localhost:4000`. Proxy target could be changed in `vite.config.mts`.
+
+## Compatibility and Versioning
+
+Please refer to the [Explorer Backend documentation](https://github.com/soramitsu/iroha2-block-explorer-backend#compatibility-and-versioning).


### PR DESCRIPTION
See:

- https://github.com/soramitsu/iroha2-block-explorer-backend/issues/74
- https://github.com/soramitsu/iroha2-block-explorer-backend/pull/76